### PR TITLE
called pynos import call instead of both

### DIFF
--- a/pynos/versions/ver_7/ver_7_0_0/interface.py
+++ b/pynos/versions/ver_7/ver_7_0_0/interface.py
@@ -1086,7 +1086,7 @@ class Interface(InterfaceBase):
                          target_community='auto')
         if get:
             enable = None
-        method_name = 'rbridge_id_evpn_instance_route_target_imprt_ignore_as'
+        method_name = 'rbridge_id_evpn_instance_route_target_both_ignore_as'
         method_class = self._rbridge
         evpn_args['rbridge_id'] = rbridge_id
         evpn_instance_rt_both_ignore_as = getattr(method_class,


### PR DESCRIPTION
called pynos import call instead of both


root@ubuntu:/opt/stackstorm/packs/network_essentials/actions# st2 run network_essentials.configure_evpn_instance mgmt_ip=10.20.34.46 evi_name=evpn7
......
id: 585394a01d41c8056e190e15
status: succeeded
parameters:
  evi_name: evpn7
  mgmt_ip: 10.20.34.46
result:
  exit_code: 0
  result:
    evpn-instance: true
  stderr: "st2.actions.python.ConfigureEvpnInstance: INFO     successfully connected to 10.20.34.46
st2.actions.python.ConfigureEvpnInstance: INFO     Configuring EVPN instance on rbridge 51
st2.actions.python.ConfigureEvpnInstance: INFO     Successfuly created EVPN instance
st2.actions.python.ConfigureEvpnInstance: INFO     Completed configuring rd auto
st2.actions.python.ConfigureEvpnInstance: INFO     Completed configuring duplicate mac timer
st2.actions.python.ConfigureEvpnInstance: INFO     Completed configuring duplicate mac timer
st2.actions.python.ConfigureEvpnInstance: INFO     Completed configuring max timer max count
st2.actions.python.ConfigureEvpnInstance: INFO     Configuring EVPN instance on rbridge 52
st2.actions.python.ConfigureEvpnInstance: INFO     Successfuly created EVPN instance
st2.actions.python.ConfigureEvpnInstance: INFO     Completed configuring rd auto
st2.actions.python.ConfigureEvpnInstance: INFO     Completed configuring duplicate mac timer
st2.actions.python.ConfigureEvpnInstance: INFO     Completed configuring duplicate mac timer
st2.actions.python.ConfigureEvpnInstance: INFO     Completed configuring max timer max count
st2.actions.python.ConfigureEvpnInstance: INFO     closing connection to 10.20.34.46 after configuring EVPN instance-- all done!
"
  stdout: ''
root@ubuntu:/opt/stackstorm/packs/network_essentials/actions#


w0#
sw0# show running-config rbridge-id evpn-instance
% No entries found.
sw0#
sw0#
sw0#
sw0#
sw0#
sw0#
sw0#
sw0#
sw0# show running-config rbridge-id evpn-instance
rbridge-id 51
 evpn-instance evpn7
  route-target both auto ignore-as
  rd auto
  duplicate-mac-timer 10 max-count 10
 !
!
rbridge-id 52
 evpn-instance evpn7
  route-target both auto ignore-as
  rd auto
  duplicate-mac-timer 10 max-count 10
 !
!
sw0# show ver

Network Operating System Software
Network Operating System Version: 7.1.0
Copyright (c) 1995-2016 Brocade Communications Systems, Inc.
Firmware name:      7.1.0
Build Time:         18:34:40 Nov 22, 2016
Install Time:       19:01:35 Dec 12, 2016
Kernel:             2.6.34.6

BootProm:           1.0.1
Control Processor:  e500mc with 8192 MB of memory

Slot    Name    Primary/Secondary Versions                         Status
---------------------------------------------------------------------------
SW/0    NOS     7.1.0                                              ACTIVE*
                7.1.0
SW/1    NOS     7.1.0                                              STANDBY
                7.1.0

sw0#
